### PR TITLE
Feature/issue 8

### DIFF
--- a/ib.py
+++ b/ib.py
@@ -15,6 +15,7 @@ from docxtpl import DocxTemplate
 from collections import namedtuple
 
 dirname = "ibdata"
+reportDirName = "reports"
 
 sections = [
     "Deposits & Withdrawals",
@@ -31,9 +32,7 @@ currencies = {
     "EUR": ["01239", "EURRUB=X", None],
 }
 
-StartDate = "20.03.2019"
-
-Year = int(input("Введите год отчета: "))
+StartDate = "01.01.2018"
 
 
 # In[2]:
@@ -92,34 +91,52 @@ def get_crs_tables():
 
 get_crs_tables()
 
+# In[]:
+
+def preprocess_reports():
+    print("Обработка отчетов по годам...")
+    years = {}
+    for fname in glob(os.path.join(reportDirName, f"*.csv")):
+        yearToProceed = int(fname.replace(reportDirName + os.path.sep, '').split('.')[0])
+        print(f"--{fname}")
+        years[yearToProceed] = fname
+    
+    return sorted(years.items(), key=lambda kv: kv[1])
+
+yearReports = preprocess_reports()
+
+if len(yearReports) == 0:
+    print(f"Не найдено отчетов в папке {reportDirName}.")
+    print("Проверьте, что в ней есть отчеты в csv формате, названные по шаблону YEAR.csv")
+    quit()
 
 # In[4]:
 
 
-def split_report():
-    print("Разделение отчета на разделы...")
-    fname = f"{Year}.csv"
-    if not os.path.exists(fname):
-        input(f"Не найден файл отчета за {Year}г. ({fname})")
-        sys.exit()
+def split_report(fileReport):
+    fname = f"{fileReport[1]}"
+    year = fileReport[0]
+    print(f"Разделение отчета {fname} на разделы...")
+    
     with open(fname, encoding="utf8") as file:
-        if not os.path.exists(dirname):
-            os.mkdir(dirname)
-        for old_file in glob(os.path.join(dirname, f"{Year}*.csv")):
-            os.remove(old_file)
-            #print("replaced ", old_file)
         out_file = None
         line = file.readline()
         while line:
-            section, header, *_ = line.split(',')
+            section, header, column, *_ = line.split(',')
             section = section
+
+            if section == "Trades" and column =="Account":
+                line = file.readline()
+                continue
+
             if header == "Header":
                 if out_file:
                     out_file.close()
                     out_file = None
                 out_fname = ""
                 if section in sections:
-                    out_fname = os.path.join(dirname, f"{Year}_{section}.csv")
+                    out_fname = os.path.join(dirname, f"{year}_{section}.csv")
+                    print(f"{out_fname} сгенерирован")
                     if os.path.exists(out_fname):  # if second header in the same section - skip header
                         out_fname = out_fname.replace(".csv", f"{file.tell()}.csv")
                     out_file = open(out_fname, 'w')
@@ -130,8 +147,20 @@ def split_report():
     if out_file:
         out_file.close()
 
-split_report()
+if not os.path.exists(dirname):
+    print(f"Создаем директорию {dirname}")
+    os.mkdir(dirname)
+else:
+    print(f"Директория {dirname} уже существует")
+    
+files = glob(os.path.join(dirname, "*"))
+for f in files:
+    print(f"Удаляем файл отчета {f}")
+    os.remove(f)
 
+for report in yearReports:
+    split_report(report)
+    
 
 # In[5]:
 
@@ -149,11 +178,11 @@ def get_ticker_price(ticker: str):
 # In[6]:
 
 
-def load_data():
-    print("Чтение разделов отчета...")
+def load_data(year):
+    print(f"Чтение разделов отчета за {year} год...")
     data = {}
     for fname in glob(os.path.join(dirname, f"*.csv")):
-        if (int(fname.replace(dirname + os.path.sep, '').split('_')[0]) > Year):
+        if (int(fname.replace(dirname + os.path.sep, '').split('_')[0]) != year):
             continue
         print(f"--{fname}")
         df = pd.read_csv(fname, thousands=',')
@@ -175,7 +204,7 @@ def load_data():
     if "Trades" in data:
         trades = data["Trades"]
         trades.columns = [col.lower() for col in trades]
-        trades = trades.rename(columns={"comm/fee": "fee", "date/time": "date", "t. price": "price"})
+        trades = trades.rename(columns={"comm/fee": "fee", "date/time": "date", "t. price": "price", "comm in usd":"fee"})
         trades = trades[trades.header == "Data"]
         trades = trades[trades.fee < 0]
         trades.date = pd.to_datetime(trades.date)
@@ -187,7 +216,7 @@ def load_data():
         comissions = comissions[comissions.header == "Data"]
         comissions = comissions[comissions.subtitle != "Total"]
         comissions.date = pd.to_datetime(comissions.date)
-        comissions = comissions[comissions.date.dt.year == Year]
+        comissions = comissions[comissions.date.dt.year == year]
     else:
         comissions = None
     if "Interest" in data:
@@ -196,7 +225,7 @@ def load_data():
         interests = interests[interests.header == "Data"]
         interests = interests[interests.currency != "Total"]
         interests.date = pd.to_datetime(interests.date)
-        interests = interests[interests.date.dt.year == Year]
+        interests = interests[interests.date.dt.year == year]
     else:
         interests = None
     if "Dividends" in data:
@@ -204,7 +233,7 @@ def load_data():
         div.columns = [col.lower() for col in div]
         div = pd.DataFrame(div[div.currency.isin(currencies)])
         div.date = pd.to_datetime(div.date)
-        div = pd.DataFrame(div[div.date.dt.year == Year])
+        div = pd.DataFrame(div[div.date.dt.year == year])
     else:
         div = None
     if div is not None and "Withholding Tax" in data:
@@ -212,7 +241,7 @@ def load_data():
         div_tax.columns = [col.lower() for col in div_tax]
         div_tax = pd.DataFrame(div_tax[div_tax.currency.isin(currencies)])
         div_tax.date = pd.to_datetime(div_tax.date)
-        div_tax = pd.DataFrame(div_tax[div_tax.date.dt.year == Year])
+        div_tax = pd.DataFrame(div_tax[div_tax.date.dt.year == year])
         if div.shape[0] != div_tax.shape[0]:
             print("Размеры таблиц дивидендов и налогов по ним не совпадают. Налог на дивиденды будет 13%")
             div_tax = None
@@ -223,66 +252,23 @@ def load_data():
         div_accurals.columns = [col.lower() for col in div_accurals]
         div_accurals = pd.DataFrame(div_accurals[div_accurals.currency.isin(currencies)])
         div_accurals.date = pd.to_datetime(div_accurals.date)
-        div_accurals = pd.DataFrame(div_accurals[div_accurals.date.dt.year == Year])
+        div_accurals = pd.DataFrame(div_accurals[div_accurals.date.dt.year == year])
     else:
         div_accurals = None
     return cashflow, trades, comissions, div, div_tax, div_accurals, interests
 
-cashflow, trades, comissions, div, div_tax, div_accurals, interests = load_data()
+cashflow = {}
+trades = {}
+comissions = {}
+div = {}
+div_tax = {}
+div_accurals = {}
+interests = {}
 
+for report in yearReports:
+    cashflow[report[0]], trades[report[0]], comissions[report[0]], div[report[0]], div_tax[report[0]], div_accurals[report[0]], interests[report[0]] = load_data(report[0])
 
-# In[ ]:
-
-
-
-
-
-# In[7]:
-
-
-def trades_add():
-    res = []
-    if datetime.today().year == Year and input("Хотите добавить сделки купли\\продажи? (y\\n) ") == "y":
-        print("Введите сделки в формате{тикер} {шт.} {валюта}. (шт.<0 - продажа, пустая строка для завершения, res - сначала)")
-        i = 0
-        while(1):
-            s = input(f"{i+1}: ")
-            spl = s.split(" ")
-            if s == "res":
-                res.clear()
-                i = 0
-                print("Сброс...")
-                continue
-            elif (len(spl) != 3):
-                break
-            else:
-                ticker, cnt, cur = spl
-                price = get_ticker_price(ticker)
-                res.append({
-                    #"trades": "Trades",
-                    #"header": "Data",
-                    #"datadiscriminator": "Order",
-                    #"asset category": "Stocks",
-                    "currency": cur.upper(),
-                    "symbol": ticker.upper(),
-                    "fee": -1.0,
-                    "date": datetime.today(),
-                    "quantity": float(cnt),
-                    "price": float(price)
-                })
-                print("Куплено" if float(cnt)>0 else "Продано", abs(float(cnt)), ticker.upper(), "по цене", price, cur)
-                i += 1
-        print(f"Добавлено {len(res)} сделок")
-    return res
-if trades is not None:
-    trades_extra = trades_add()
-    for i, trade in enumerate(trades_extra):
-        cur = trade["currency"]
-        if cur in currencies:
-            trades = trades.append(trade, ignore_index=True)
-        else:
-            print(f"Неизвестная валюта {cur}, сделка № {i+1} не используется")
-
+print(div[2020])
 
 # In[8]:
 
@@ -300,21 +286,31 @@ def get_currency(date, cur):
 # In[9]:
 
 
-def cashflow_calc():
-    print(f"Расчет таблицы переводов...")
-    res = cashflow[["date", "currency", "amount"]].copy()
-    res["type"] = ["Перевод на счет" if amount > 0 else "Снятие со счета" for amount in cashflow.amount]
+def cashflow_calc(year):
+    print(f"Расчет таблицы переводов за {year} год...")
+    if cashflow[year] is None:
+        print(f"За {year} нет переводов")
+        return None, None, None, None
+    res = cashflow[year][["date", "currency", "amount"]].copy()
+    res["type"] = ["Перевод на счет" if amount > 0 else "Снятие со счета" for amount in cashflow[year].amount]
     cashflow_rub_sum = res[res.currency == "RUB"].amount.sum().round(2)
     cashflow_usd_sum = res[res.currency == "USD"].amount.sum().round(2)
     cashflow_eur_sum = res[res.currency == "EUR"].amount.sum().round(2)
+    print(f"За {year} год:")
+    print(res)
+    print(f"Rub: {cashflow_rub_sum}")
+    print(f"Usd: {cashflow_usd_sum}")
+    print(f"Eur: {cashflow_eur_sum}")
     return res, cashflow_rub_sum, cashflow_usd_sum, cashflow_eur_sum
 
+cashflow_res = {}
+cashflow_rub_sum = {}
+cashflow_usd_sum = {}
+cashflow_eur_sum = {}
+
 if cashflow is not None:
-    cashflow_res, cashflow_rub_sum, cashflow_usd_sum, cashflow_eur_sum = cashflow_calc()
-    print("\ncashflow_res:")
-    print(cashflow_res.head(2))
-    print(cashflow_rub_sum, cashflow_usd_sum, cashflow_eur_sum)
-    print("\n")
+    for report in yearReports:
+        cashflow_res[report[0]], cashflow_rub_sum[report[0]], cashflow_usd_sum[report[0]], cashflow_eur_sum[report[0]] = cashflow_calc(report[0])
 else:
     print("Нет данных по переводам")
 
@@ -322,35 +318,50 @@ else:
 # In[10]:
 
 
-def div_calc():
-    print(f"Расчет таблицы дивидендов...")
+def div_calc(year):
+    print(f"Расчет таблицы дивидендов за {year} год...")
+    if div[year] is None:
+        print(f"За {year} нет дивидендов")
+        return None
+
     res = pd.DataFrame()
-    res["ticker"] = [desc.split(" Cash Dividend")[0] for desc in div.description]
-    res["date"] = div["date"].values
-    res["amount"] = div["amount"].values.round(2)
-    res["currency"] = div["currency"].values
-    if div_tax is None:
+    res["ticker"] = [desc.split(" Cash Dividend")[0] for desc in div[year].description]
+    res["date"] = div[year]["date"].values
+    res["amount"] = div[year]["amount"].values.round(2)
+    res["currency"] = div[year]["currency"].values
+    if div_tax[year] is None:
         print("Не найдена таблица удержанного налога с дивидендов. Налог на дивиденды будет 13%")
-    res["tax_paid"] = -div_tax["amount"].values.round(2) if div_tax is not None else 0
-    res["cur_price"] = [get_currency(row.date, row.currency) for _, row in div.iterrows()]
+    res["tax_paid"] = -div_tax[year]["amount"].values.round(2) if div_tax[year] is not None else 0
+    res["cur_price"] = [get_currency(row.date, row.currency) for _, row in div[year].iterrows()]
     res["amount_rub"] = (res.amount*res.cur_price).round(2)
     res["tax_paid_rub"] = (res.tax_paid*res.cur_price).round(2)
     res["tax_full_rub"] = (res.amount_rub*13/100).round(2)
     res["tax_rest_rub"] = (res.tax_full_rub - res.tax_paid_rub).round(2)
+
     return res
 
+div_res = {}
+div_sum = {}
+div_tax_paid_rub_sum = {}
+div_tax_full_rub_sum = {}
+div_tax_rest_sum = {}
+
 if div is not None:
-    div_res = div_calc()
-    div_sum = round(div_res.amount_rub.sum(), 2)
-    div_tax_paid_rub_sum = round(div_res.tax_paid_rub.sum(), 2)
-    div_tax_full_rub_sum = round(div_res.tax_full_rub.sum(), 2)
-    div_tax_rest_sum = round(div_res.tax_rest_rub.sum(), 2)
-    print("\ndiv_res:")
-    print(div_res.head(2))
-    print("\n")
+    for report in yearReports:
+        div_res[report[0]] = div_calc(report[0])
+        if div_res[report[0]] is None:
+            div_sum[report[0]] = None
+            div_tax_paid_rub_sum[report[0]] = None
+            div_tax_full_rub_sum[report[0]] = None
+            div_tax_rest_sum[report[0]] = None
+        else:
+            div_sum[report[0]] = round(div_res[report[0]].amount_rub.sum(), 2)
+            div_tax_paid_rub_sum[report[0]] = round(div_res[report[0]].tax_paid_rub.sum(), 2)
+            div_tax_full_rub_sum[report[0]] = round(div_res[report[0]].tax_full_rub.sum(), 2)
+            div_tax_rest_sum[report[0]] = round(div_res[report[0]].tax_rest_rub.sum(), 2)
+            print(f"Дивидендов за {report[0]} год: {div_sum[report[0]]} Rub")
 else:
     print("Нет данных по начисленным дивидендам")
-
 
 # In[11]:
 
@@ -484,7 +495,8 @@ def trades_calc():
                 print("--Можно продать", cnt, key, "и получить", abs(round(res, 2)), "р. бумажного убытка")
         print("\n")
     return pd.DataFrame(rows, columns=['ticker', 'date', 'price', 'fee', 'cnt', 'currency'])
-if "trades" is not None:
+
+if trades is not None:
     trades_res = trades_calc()
     if len(trades_res):
         trades_res = trades_res.groupby(['ticker', 'date', 'price', 'fee', 'currency'], as_index=False)['cnt'].sum()
@@ -583,7 +595,6 @@ create_doc()
 
 
 input("Готово.")
-os.startfile(Fname, "open")
 
 
 # In[ ]:


### PR DESCRIPTION
Глобальный рефакторинг и поддержка перехода "через года"

- Не надо вводить год, просто необходимо положить отчеты в папку reports и запустить скрипт, он сам пройдет и найдет все.
- Переработана логика обработки позиций - всё загружается по годам в переменные xxx[year], и логика поиска позиации такая, что всегда есть массив купленных позиций. Как только находим очередную продажу - берем из начала списка позицию, добавляем необходимое кол-во купил-продал. Если не хватает - не добавляем, шортить нельзя.
- Создаются пояснительные записки сразу за все года.
- Добавлено больше информации при работе скрипта в логах.
- Убрано в TODO заметка, чтобы предложить налоговую оптимизацию, которая была убрана, т.к. переработана логика обработки сделок.