### PR TITLE
Support sorted trades by dates

### DIFF
--- a/ib.py
+++ b/ib.py
@@ -428,6 +428,8 @@ def trades_calc():
     assets = {}
     rows = []
     for key, val in trades.groupby("symbol"):
+    normalizedTrades = trades.sort_values(['date'], ascending=True).groupby("symbol")
+    for key, val in normalizedTrades:
         fail = False
         if not key in assets:
             assets[key] = []

--- a/ib.py
+++ b/ib.py
@@ -112,8 +112,11 @@ def split_report():
         out_file = None
         line = file.readline()
         while line:
-            section, header, *_ = line.split(',')
+            section, header, column, *_ = line.split(',')
             section = section
+            if section == "Trades" and column =="Account":
+                line = file.readline()
+                continue
             if header == "Header":
                 if out_file:
                     out_file.close()

--- a/ib.py
+++ b/ib.py
@@ -427,7 +427,6 @@ def trades_calc():
     Asset = namedtuple("Asset", "date price fee currency")
     assets = {}
     rows = []
-    for key, val in trades.groupby("symbol"):
     normalizedTrades = trades.sort_values(['date'], ascending=True).groupby("symbol")
     for key, val in normalizedTrades:
         fail = False


### PR DESCRIPTION
Сортировка таблицы трейдов, т.к. они должны переходить через год, а именно, если обрабатываем 2020, надо, чтобы 2019 точно был перед ним.