### PR TITLE
Добавлен учета номинала в расчете курса валюты

### DIFF
--- a/ib.py
+++ b/ib.py
@@ -333,7 +333,8 @@ def get_currency(date, cur):
     data = currencies[cur][2]
     diff = (data.date - date)
     indexmax = (diff[(diff <= pd.to_timedelta(0))].idxmax())
-    return float(data.iloc[[indexmax]].val)
+    assert float(data.iloc[[indexmax]].nominal) != 0.0, f"Номинал валюты не может быть 0"
+    return float(data.iloc[[indexmax]].val) / float(data.iloc[[indexmax]].nominal)
 
 
 # In[9]:


### PR DESCRIPTION
В некоторых валютах в таблице курсов ЦБ меняется номинал - в этом случае необходимо курс из колонки "Curs" поделить на номинал (колонка "Nominal").

Пример норвежской кроны:

<img width="360" alt="Screenshot 2022-03-24 at 14 22 20" src="https://user-images.githubusercontent.com/58659048/159937810-098509db-5f58-425d-9509-79cb9195ddb6.png">

